### PR TITLE
Friendly message when netcat is not installed

### DIFF
--- a/snowdrift
+++ b/snowdrift
@@ -397,7 +397,7 @@ function testPath() {
 		#
 		# Additional condition to check if Netcat is installed 
 		# and friendly error message
-		#
+		# 
 		CMD=$(cat << EOF
 			if test -x /usr/bin/nc
 			then 

--- a/snowdrift
+++ b/snowdrift
@@ -77,7 +77,7 @@ function getColor() {
 	then
 		RETVAL=$RED
 
-	elif test "$OUTPUT" == "FAIL"
+	elif [[ "$OUTPUT" =~ FAIL.* ]]
 	then
 		RETVAL=$RED
 
@@ -225,6 +225,10 @@ function parseOutput() {
 		elif [[ "$OUTPUT" == "dns:FAIL" ]]
 		then
 			echo "FAIL"
+
+                elif [[ "$OUTPUT" =~ Netcat\ not\ installed ]]
+                then
+                        echo "FAIL: $OUTPUT"
 
 		elif [[ "$OUTPUT" == "" ]]
 		then
@@ -391,6 +395,9 @@ function testPath() {
 		#
 		# This will run on the source host.
 		#
+		# Additional condition to check if Netcat is installed 
+		# and friendly error message
+		#
 		CMD=$(cat << EOF
 			if test -x /usr/bin/nc
 			then 
@@ -404,14 +411,18 @@ function testPath() {
 
 			#echo "Netcat DEBUG: ${NETCAT} ${TIMEOUT} ${DEST} ${PORT} OPENBSD=\${IS_OPENBSD}"; exit 1
 
-			if test "\$IS_OPENBSD"
-			then
-				\$NETCAT -vz -w${TIMEOUT} $DEST $PORT </dev/null 2>&1 
+                        if test "\$NETCAT" 
+                        then
+                                if test "\$IS_OPENBSD"
+                                then
+                                        \$NETCAT -vz -w${TIMEOUT} $DEST $PORT </dev/null 2>&1
 
-			else
-				\$NETCAT -v -w${TIMEOUT} $DEST $PORT </dev/null 2>&1 
-
-			fi
+                                else
+                                        \$NETCAT -v -w${TIMEOUT} $DEST $PORT </dev/null 2>&1
+                                fi
+                        else
+                                echo "[\`hostname\`] Netcat not installed";
+                        fi
 
 EOF
 )


### PR DESCRIPTION
Hi Guys,
I've added friendly message when Netcat is not installed.
It shows e.g.:
17:14:17  Port testing: hostname1 -> hostname2:50505: FAIL: [hostname1] Netcat not installed

Would be nice to have such info. Now it shows
17:14:17  Port testing: hostname1 -> hostname2:50505: [UNKNOWN] UNKNOWN: ksh: -v:  not found

Best regards,
Robert L (ladrob)