### PR TITLE
Test overhaul

### DIFF
--- a/files/snowdrift-tests.txt
+++ b/files/snowdrift-tests.txt
@@ -6,60 +6,60 @@
 # Ports 450-459: Nothing listening (connection refused)
 #
 
-source:dest01:80
-source:dest01:81
-source:dest01:440
-source:dest01:441
-source:dest01:450
-source:dest01:451
+test2/source:dest01:80:OK
+test2/source:dest01:81:OK
+test/source:dest01:440:Timeout
+test/source:dest01:441:Timeout
+test2/source:dest01:450:Empty string received.
+test2/source:dest01:451:Empty string received.
 
-source-no-netcat:dest01:80
-source-no-netcat:dest01:81
-source-no-netcat:dest01:440
-source-no-netcat:dest01:441
-source-no-netcat:dest01:450
-source-no-netcat:dest01:451
+source-no-netcat:dest01:80:Netcat not installed
+source-no-netcat:dest01:81:Netcat not installed
+source-no-netcat:dest01:440:Netcat not installed
+source-no-netcat:dest01:441:Netcat not installed
+source-no-netcat:dest01:450:Netcat not installed
+source-no-netcat:dest01:451:Netcat not installed
 
-source-netcat-openbsd:dest01:80
-source-netcat-openbsd:dest01:81
-source-netcat-openbsd:dest01:440
-source-netcat-openbsd:dest01:441
-source-netcat-openbsd:dest01:450
-source-netcat-openbsd:dest01:451
+test/source-netcat-openbsd:dest01:80:OK
+source-netcat-openbsd:dest01:81:OK
+source-netcat-openbsd:dest01:440:Timeout
+source-netcat-openbsd:dest01:441:Timeout
+source-netcat-openbsd:dest01:450:OK - Connection Refused
+source-netcat-openbsd:dest01:451:OK - Connection Refused
 
-range/source-netcat-openbsd:dest[01-03]:80
-range/source-netcat-openbsd:dest01:[80-82]
-range/source-netcat-openbsd:dest[01-03]:[80-82]
-range/source-netcat-openbsd:dest01:[440-442]
-range/source-netcat-openbsd:dest01:[450-452]
+range/source-netcat-openbsd:dest[01-03]:80:OK
+range/source-netcat-openbsd:dest01:[80-82]:OK
+range/source-netcat-openbsd:dest[01-03]:[80-82]:OK
+range/source-netcat-openbsd:dest01:[440-442]:Timeout
+range/source-netcat-openbsd:dest01:[450-452]:OK - Connection Refused
 
-comma/source-netcat-openbsd:dest[01-03]:80
-comma/source-netcat-openbsd:dest01:[80,81,82]
-comma/source-netcat-openbsd:dest[01-03]:[80,81,82]
-comma/source-netcat-openbsd:dest01:[440,441,442]
-comma/source-netcat-openbsd:dest01:[450,451,452]
+comma/source-netcat-openbsd:dest[01-03]:80:OK
+comma/source-netcat-openbsd:dest01:[80,81,82]:OK
+comma/source-netcat-openbsd:dest[01-03]:[80,81,82]:OK
+comma/source-netcat-openbsd:dest01:[440,441,442]:Timeout
+comma/source-netcat-openbsd:dest01:[450,451,452]:OK - Connection Refused
 
 
-source-centos:dest01:80
-source-centos:dest01:81
-source-centos:dest01:440
-source-centos:dest01:441
-source-centos:dest01:450
-source-centos:dest01:451
+source-centos:dest01:80:OK
+source-centos:dest01:81:OK
+source-centos:dest01:440:Timeout
+source-centos:dest01:441:Timeout
+source-centos:dest01:450:OK - Connection Refused
+source-centos:dest01:451:OK - Connection Refused
 
-source-ubuntu:dest01:80
-source-ubuntu:dest01:81
-source-ubuntu:dest01:440
-source-ubuntu:dest01:441
-source-ubuntu:dest01:450
-source-ubuntu:dest01:451
+source-ubuntu:dest01:80:OK
+source-ubuntu:dest01:81:OK
+source-ubuntu:dest01:440:Timeout
+source-ubuntu:dest01:441:Timeout
+source-ubuntu:dest01:450:OK - Connection Refused
+source-ubuntu:dest01:451:OK - Connection Refused
 
-source-ubuntu-openbsd:dest01:80
-source-ubuntu-openbsd:dest01:81
-source-ubuntu-openbsd:dest01:440
-source-ubuntu-openbsd:dest01:441
-source-ubuntu-openbsd:dest01:450
-source-ubuntu-openbsd:dest01:451
+source-ubuntu-openbsd:dest01:80:OK:OK
+source-ubuntu-openbsd:dest01:81:OK:OK
+source-ubuntu-openbsd:dest01:440:Timeout
+source-ubuntu-openbsd:dest01:441:Timeout
+source-ubuntu-openbsd:dest01:450:OK - Connection Refused
+source-ubuntu-openbsd:dest01:451:OK - Connection Refused
 
 
 

--- a/snowdrift
+++ b/snowdrift
@@ -69,20 +69,41 @@ function getColor() {
 	OUTPUT=$1
 
 	RETVAL=$NC
-	if [[ "$OUTPUT" =~ OK.* ]]
-	then
-		RETVAL=$GREEN
 
-	elif [[ "$OUTPUT" =~ Timeout.* ]]
+	if test ! "${EXTRA}"
 	then
-		RETVAL=$RED
 
-	elif [[ "$OUTPUT" =~ FAIL.* ]]
-	then
-		RETVAL=$RED
+		if [[ "$OUTPUT" =~ OK.* ]]
+		then
+			RETVAL=$GREEN
+
+		elif [[ "$OUTPUT" =~ Timeout.* ]]
+		then
+			RETVAL=$RED
+
+		elif [[ "$OUTPUT" =~ FAIL.* ]]
+		then
+			RETVAL=$RED
+
+		else
+			RETVAL="$RED[UNKNOWN] "
+
+		fi
 
 	else
-		RETVAL="$RED[UNKNOWN] "
+		#
+		# If the extra value present and in our output string,
+		# change the color to green, because it's expected.
+		#
+		# That way, if we're REALLY expecting things like "Connection refused", that's okay.
+		#
+		#echo "OUTPUT, EXTRA: ${OUTPUT}, ${EXTRA}" # Debugging
+		if [[ "${OUTPUT}" =~ "${EXTRA}" ]]
+		then
+			RETVAL=$GREEN
+		else
+			RETVAL=$RED
+		fi
 
 	fi
 
@@ -97,13 +118,34 @@ function getColor() {
 function updateStats() {
 
 	STR=$1
-	if [[ "$STR" =~ OK.* ]]
+	EXTRA=$2
+
+	if test ! "${EXTRA}"
 	then
-		STATS_SUCCESS=$(( STATS_SUCCESS + 1 ))
-		STATS_TOTAL_SUCCESS=$(( STATS_TOTAL_SUCCESS + 1 ))
+
+		if [[ "$STR" =~ OK.* ]]
+		then
+			STATS_SUCCESS=$(( STATS_SUCCESS + 1 ))
+			STATS_TOTAL_SUCCESS=$(( STATS_TOTAL_SUCCESS + 1 ))
+		else
+			STATS_FAIL=$(( STATS_FAIL + 1 ))
+			STATS_TOTAL_FAIL=$(( STATS_TOTAL_FAIL + 1 ))
+		fi
+
 	else
-		STATS_FAIL=$(( STATS_FAIL + 1 ))
-		STATS_TOTAL_FAIL=$(( STATS_TOTAL_FAIL + 1 ))
+		#
+		# If there's an expected string, check to see that it exists
+		# in the string that we got.
+		#
+		if [[ "${STR}" =~ "${EXTRA}" ]]
+		then
+			STATS_SUCCESS=$(( STATS_SUCCESS + 1 ))
+			STATS_TOTAL_SUCCESS=$(( STATS_TOTAL_SUCCESS + 1 ))
+		else
+			STATS_FAIL=$(( STATS_FAIL + 1 ))
+			STATS_TOTAL_FAIL=$(( STATS_TOTAL_FAIL + 1 ))
+		fi
+
 	fi
 
 } # End of updateStats()
@@ -212,7 +254,7 @@ function parseOutput() {
 
 		elif [[ "$OUTPUT" =~ .*refused.* ]]
 		then
-			echo "OK: Connection Refused"
+			echo "OK - Connection Refused"
 
 		elif [[ "$OUTPUT" =~ .*timed\ out.* ]]
 		then
@@ -232,7 +274,7 @@ function parseOutput() {
 
 		elif [[ "$OUTPUT" == "" ]]
 		then
-			echo "(Empty string received. Are you running BusyBox? Try OpenBSD netcat instead!"
+			echo "(Empty string received. Are you running BusyBox? Try OpenBSD netcat instead!)"
 
 		else
 			echo "UNKNOWN: $OUTPUT"
@@ -367,6 +409,9 @@ function testPath() {
 	PORT=$3
 	TAG=$4
 	EXTRA=$5
+	EXTRA2=$5
+
+	#echo "EXTRA: ${EXTRA}, ${EXTRA2}" # Debugging
 
 	#
 	# Were we able to SSH to this host? If not, do a quick test!
@@ -502,8 +547,26 @@ EOF
 		echo "SSH OUTPUT: $OUTPUT"
 	fi
 
+	#
+	# Turn our raw output into a well structured string.
+	#
 	OUTPUT=$(parseOutput "$PORT" "$OUTPUT" "$RETVAL")
+
 	COLOR=$(getColor $OUTPUT)
+
+	#
+	# If we have expected output, check for a match.
+	#
+	if test "${EXTRA}"
+	then
+		if [[ "${OUTPUT}" =~ "${EXTRA}" ]]
+		then
+			true
+		else
+			OUTPUT="${OUTPUT} ('${EXTRA}' expected)"
+		fi
+	fi
+
 	echo -e "${COLOR}$OUTPUT${NC}"
 
 	#
@@ -511,7 +574,7 @@ EOF
 	#
 	doTraceroutes "$SRC" "$DEST" "$PORT" "$OUTPUT"
 
-	updateStats $OUTPUT
+	updateStats ${OUTPUT} ${EXTRA}
 
 } # End of testPath()
 
@@ -528,8 +591,9 @@ function printSyntax() {
 	echo "! "
 	echo "! 	Rules format:"
 	echo "! "
-	echo "! 		[tag/]\$source_host:\$dest_host:\$tcp_port"
+	echo "! 		[tag/]\$source_host:\$dest_host:\$tcp_port:[Expected text]"
 	echo "! 			SSH into source_host and use netcat to connec to dest_host on specified TCP port"
+	echo "!			If 'Expected text' is specified, it will be checked to see if it matches the status.  If not, it's treated as an error and will show up in red.  If it does match, it shows up in green and PASSES."
 	echo "! "
 	echo "! 		[tag/]\$source_host:[\$dns_server]:dns:[\$hostname]"
 	echo "! 			SSH into source_host and use dig to lookup a hostname against the specified DNS server."
@@ -691,6 +755,7 @@ function processFile() {
 	for LINE in $(cat $FILE)
 	do
 
+		#echo "LINE: ${LINE}" # Debugging
 		if test "$(skipLine $LINE)" != ""
 		then
 			continue
@@ -711,6 +776,8 @@ function processFile() {
 		DEST=${FIELDS[1]}
 		PORT=${FIELDS[2]}
 		EXTRA=${FIELDS[3]}
+		EXTRA2=${FIELDS[4]}
+		#echo "EXTRA: ${EXTRA}, ${EXTRA2}" # Debugging
 
 		#
 		# Parse out our tag.
@@ -764,7 +831,7 @@ function processFile() {
 			do
 				for PORT in ${RANGE_PORTS[@]}
 				do
-					testPath "$SRC" "$DEST" "$PORT" "$TAG" "$EXTRA"
+					testPath "$SRC" "$DEST" "$PORT" "$TAG" "$EXTRA" "$EXTRA2"
 				done
 			done
 		done

--- a/test.sh
+++ b/test.sh
@@ -130,7 +130,12 @@ then
 	exit 1
 fi
 
+
+#
+# Run snowdrift in the testing container with our test file.
+#
 docker-compose exec testing /mnt/snowdrift /mnt/${TMP_TESTS} | tee $TMP
+
 
 RESULTS=$(cat $TMP)
 rm -f $TMP $TMP_TESTS
@@ -145,8 +150,8 @@ TOTAL_CONNS_FAILED=$(getMetric "Total Failed Connections: ")
 compareValues "Num tests where Netcat not installed" $NUM_NETCAT_NOT_INSTALLED "6"
 compareValues "Total Hosts Successful" $TOTAL_HOSTS_SUCCESS "6"
 compareValues "Total Hosts Failed" $TOTAL_HOSTS_FAILED "ZERO"
-compareValues "Total Connections Successful" $TOTAL_CONNS_SUCCESS "54"
-compareValues "Total Connections Failed" $TOTAL_CONNS_FAILED "24"
+compareValues "Total Connections Successful" $TOTAL_CONNS_SUCCESS "78"
+compareValues "Total Connections Failed" $TOTAL_CONNS_FAILED "ZERO"
 
 
 echo "# Done!"


### PR DESCRIPTION

I overhauled the app so that the config file can have "expected" strings like this:

```
source-no-netcat:dest01:451:Netcat not installed
source-netcat-openbsd:dest01:440:Timeout
source-netcat-openbsd:dest01:450:OK - Connection Refused
```

The end result is that "expected" errors still used to count as errors:

<img width="687" alt="tests-old" src="https://user-images.githubusercontent.com/374060/107865003-8263db80-6e30-11eb-81b9-e13bf7bf4b93.png">

Now they don't:

<img width="691" alt="tests-new" src="https://user-images.githubusercontent.com/374060/107865004-8263db80-6e30-11eb-8caf-1eff6c8095b1.png">

Obviously, this assumes that the user knows what they're doing when writing the configuration file.

The big reason I wrote this was because the old style output was slightly confusing when running tests, and it slowed down the process of getting PR #7 integrated.  I'd like to avoid that sort of thing in the future. :-)


